### PR TITLE
Fix country/region tax rates not restored on import

### DIFF
--- a/src/uSync.Umbraco.Commerce/Serializers/ShippingMethodSerializer.cs
+++ b/src/uSync.Umbraco.Commerce/Serializers/ShippingMethodSerializer.cs
@@ -138,8 +138,8 @@ namespace uSync.Umbraco.Commerce.Serializers
             var valuesToRemove = item
                 .AllowedCountryRegions.Where(x =>
                     countryRegions == null
-                    || !item.AllowedCountryRegions.Any(y =>
-                        y.CountryId == x.CountryId && y.RegionId == y.RegionId
+                    || !countryRegions.Any(y =>
+                        y.CountryId == x.CountryId && y.RegionId == x.RegionId
                     )
                 )
                 .ToList();

--- a/src/uSync.Umbraco.Commerce/Serializers/TaxClassSerializer.cs
+++ b/src/uSync.Umbraco.Commerce/Serializers/TaxClassSerializer.cs
@@ -65,7 +65,7 @@ namespace uSync.Umbraco.Commerce.Serializers
                         new XElement("CountryId", rate.CountryId),
                         new XElement("RegionId", rate.RegionId),
                         new XElement("TaxCode", rate.TaxCode),
-                        new XElement("TaxRate", rate.TaxRate)
+                        new XElement("TaxRate", rate.TaxRate.Value)
                     )
                 );
             }
@@ -136,7 +136,7 @@ namespace uSync.Umbraco.Commerce.Serializers
             var taxRates = new List<SyncTaxRateModel>();
 
             // load the regions from the xml.
-            var root = node.Element("TaxRates");
+            var root = node.Element("TaxClasses");
             if (root != null && root.HasElements)
             {
                 foreach (var value in root.Elements("Rate"))
@@ -147,6 +147,7 @@ namespace uSync.Umbraco.Commerce.Serializers
                             CountryId = value.GetGuidValue("CountryId"),
                             RegionId = value.GetGuidValue("RegionId"),
                             Rate = value.Element("TaxRate").ValueOrDefault((decimal)0),
+                            TaxCode = value.Element("TaxCode").ValueOrDefault(string.Empty),
                         }
                     );
                 }


### PR DESCRIPTION
## Summary
- Fixes #10 — `TaxClassSerializer` wrote country/region tax overrides under a `<TaxClasses>` element but read them back looking for `<TaxRates>`, so import always saw an empty list, applied nothing from the XML, and cleared every existing override as "not in the XML".
- Fixes the exported tax rate value itself: `rate.TaxRate` is a `TaxRate` object whose `ToString()` renders as `"20.00%"`, which fails to parse back to `decimal` on import and silently defaults to `0`. Now exports `rate.TaxRate.Value`, matching the existing `DefaultTaxRate` pattern. `TaxCode` is now round-tripped as well.
- While in the area, fixed the same collection-diff pattern in `ShippingMethodSerializer.DeserializeCountryRegionsAsync`, which compared the live `AllowedCountryRegions` list against itself (with a `y.RegionId == y.RegionId` tautology) instead of against the country/regions parsed from the XML, so stale allowances were never removed on import.

## Test plan
- [x] `dotnet build` succeeds with no new warnings/errors
- [ ] Manual repro against a running Umbraco + Commerce site: configure a Tax Class with country/region overrides (rate + tax code), export, change/disable the overrides in the backoffice, import, and verify the overrides (rate, tax code, enabled state) are restored to match the exported XML
- [ ] Re-export after import and diff against the original XML to confirm round-trip stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)